### PR TITLE
Fix: cloudsmith handling development repositories, release 0.3.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,8 @@ classifiers =
     Operating System :: OS Independent
 
 [options]
+install_requires = 
+    requests == 2.*
 packages = upgrade.scripts
 zip_safe = False
 include_package_data = True

--- a/upgrade/scripts/upgrade_python_package.py
+++ b/upgrade/scripts/upgrade_python_package.py
@@ -8,6 +8,7 @@ import glob
 import argparse
 from importlib import util
 from pathlib import Path
+import requests
 import site
 
 
@@ -203,6 +204,14 @@ def install_wheel(
             else:
                 raise
     return resp
+
+
+def is_cloudsmith_url_valid(cloudsmith_url):
+    response = requests.get(cloudsmith_url)
+    if response.status_code != 200:
+        raise Exception(
+            f"Failed to reach cloudsmith. Provided invalid URL: {cloudsmith_url}"
+        )
 
 
 def is_package_already_installed(package):
@@ -490,6 +499,8 @@ def upgrade_python_package(
                 level=logging.WARNING,
                 format="%(asctime)s %(message)s",
             )
+        if cloudsmith_url:
+            is_cloudsmith_url_valid(cloudsmith_url)
         wheels_path = wheels_path or "/vagrant/wheels"
         if update_from_local_wheels:
             upgrade_from_local_wheel(

--- a/upgrade/scripts/upgrade_python_package.py
+++ b/upgrade/scripts/upgrade_python_package.py
@@ -502,12 +502,12 @@ def upgrade_python_package(
             *vars,
         )
     if format_output:
-        response = {
-            "success": success,
-            "responseError": response_err
-        }
-        logging.info(json.dumps(response))
-        print(json.dumps(response))
+        while len(logging.root.handlers) > 0:
+            logging.root.removeHandler(logging.root.handlers[-1])
+        logging.basicConfig(level=logging.DEBUG, format="%(asctime)s %(message)s")
+        response = json.dumps({"success": success, "responseError": response_err})
+        logging.info(response)
+        print(response)
 
 
 def main():

--- a/upgrade/scripts/upgrade_python_package.py
+++ b/upgrade/scripts/upgrade_python_package.py
@@ -480,35 +480,38 @@ def upgrade_python_package(
 ):
     success = False
     response_err = ""
-    if test:
-        logging.basicConfig(level=logging.DEBUG, format="%(asctime)s %(message)s")
-    else:
-        log_location = log_location or "/var/log/upgrade_python_package.log"
-        logging.basicConfig(
-            filename=log_location,
-            level=logging.WARNING,
-            format="%(asctime)s %(message)s",
-        )
-    wheels_path = wheels_path or "/vagrant/wheels"
-    if update_from_local_wheels:
-        upgrade_from_local_wheel(
-            package,
-            skip_post_install,
-            wheels_path=wheels_path,
-            cloudsmith_url=cloudsmith_url,
-            *vars,
-        )
-    elif should_run_initial_post_install:
-        run_initial_post_install(package, *vars)
-    else:
-        success, response_err = upgrade_and_run(
-            package,
-            force,
-            skip_post_install,
-            version,
-            cloudsmith_url,
-            *vars,
-        )
+    try:
+        if test:
+            logging.basicConfig(level=logging.DEBUG, format="%(asctime)s %(message)s")
+        else:
+            log_location = log_location or "/var/log/upgrade_python_package.log"
+            logging.basicConfig(
+                filename=log_location,
+                level=logging.WARNING,
+                format="%(asctime)s %(message)s",
+            )
+        wheels_path = wheels_path or "/vagrant/wheels"
+        if update_from_local_wheels:
+            upgrade_from_local_wheel(
+                package,
+                skip_post_install,
+                wheels_path=wheels_path,
+                cloudsmith_url=cloudsmith_url,
+                *vars,
+            )
+        elif should_run_initial_post_install:
+            run_initial_post_install(package, *vars)
+        else:
+            success, response_err = upgrade_and_run(
+                package,
+                force,
+                skip_post_install,
+                version,
+                cloudsmith_url,
+                *vars,
+            )
+    except Exception as e:
+        response_err += str(e)
     if format_output:
         while len(logging.root.handlers) > 0:
             logging.root.removeHandler(logging.root.handlers[-1])

--- a/upgrade/scripts/upgrade_python_package.py
+++ b/upgrade/scripts/upgrade_python_package.py
@@ -88,10 +88,7 @@ def install_with_constraints(
         ]
         if constraints_file_path:
             logging.info("Installing wheel with constraints %s", wheel_path)
-            args.extend([
-                "-c",
-                constraints_file_path
-            ])
+            args.extend(["-c", constraints_file_path])
         else:
             # install without constraints for backwards compatibility
             logging.info(
@@ -99,17 +96,21 @@ def install_with_constraints(
                 wheel_path,
             )
         if local:
-            args.extend([
-                "--find-links",
-                wheels_dir,
-            ])
+            args.extend(
+                [
+                    "--find-links",
+                    wheels_dir,
+                ]
+            )
         if cloudsmith_url:
-            args.extend([
-                "--extra-index-url",
-                "https://pypi.python.org/simple/",
-                "--index-url",
-                cloudsmith_url,
-            ])
+            args.extend(
+                [
+                    "--extra-index-url",
+                    "https://pypi.python.org/simple/",
+                    "--index-url",
+                    cloudsmith_url,
+                ]
+            )
         resp = pip(*args)
         return resp
     except Exception:
@@ -118,7 +119,9 @@ def install_with_constraints(
         raise
 
 
-def install_wheel(package_name, cloudsmith_url=None, local=False, wheels_path=None, version_cmd=None):
+def install_wheel(
+    package_name, cloudsmith_url=None, local=False, wheels_path=None, version_cmd=None
+):
     """
     Try to install a wheel with no-deps and if there are no broken dependencies, pass it.
     If there are broken dependencies, try to install it with constraints.
@@ -135,7 +138,9 @@ def install_wheel(package_name, cloudsmith_url=None, local=False, wheels_path=No
             raise
         to_install = wheel + extra
     else:
-        to_install = package_name + version_cmd if version_cmd is not None else package_name
+        to_install = (
+            package_name + version_cmd if version_cmd is not None else package_name
+        )
     try:
         # check if the wheel is already installed
         show_package = package_name.split("==")[0] if local else package_name
@@ -228,8 +233,15 @@ def attempt_upgrade(package_install_cmd, cloudsmith_url=None, *args):
     match = development_index_re.search(pip_config) or "--pre" in str(args)
     if match:
         pip_args.append("--pre")
-    if cloudsmith_url is not None:
-        pip_args.append(f'--index-url={cloudsmith_url}')
+    if cloudsmith_url:
+        pip_args.extend(
+            [
+                "--extra-index-url",
+                "https://pypi.python.org/simple/",
+                "--index-url",
+                cloudsmith_url,
+            ]
+        )
     resp = pip("install", *pip_args, "--upgrade", package_install_cmd)
     was_upgraded = "Requirement already up-to-date" not in resp
     if was_upgraded:
@@ -467,6 +479,7 @@ def upgrade_python_package(
             *vars,
         )
 
+
 def main():
     parsed_args = parser.parse_args()
     test = parsed_args.test
@@ -492,6 +505,7 @@ def main():
         update_from_local_wheels,
         *parsed_args.vars,
     )
+
 
 if __name__ == "__main__":
     main()

--- a/upgrade/tests/conftest.py
+++ b/upgrade/tests/conftest.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from upgrade.scripts.utils import is_windows
 from upgrade.scripts.upgrade_python_package import pip, run
 
-CLOUDSMITH_KEY = os.environ.get("CLOUDSMITH_KEY")
+CLOUDSMITH_URL = os.environ.get("CLOUDSMITH_URL", False)
 
 REPOSITORY_WHEELS_PATH = Path(__file__).parent / "repository"
 VENV_PATH = Path(__file__).parent / "venv"

--- a/upgrade/tests/test_check_cloudsmith_url.py
+++ b/upgrade/tests/test_check_cloudsmith_url.py
@@ -1,0 +1,27 @@
+from upgrade.scripts.upgrade_python_package import is_cloudsmith_url_valid
+from contextlib import nullcontext as does_not_raise
+from .conftest import CLOUDSMITH_URL
+import pytest
+
+
+def test_check_cloudsmith_url_where_url_is_invalid_expect_error():
+    cut = is_cloudsmith_url_valid
+    invalid_cloudsmith_url = (
+        "https://dl.cloudsmith.io/test/test/test/"
+    )
+    with pytest.raises(Exception) as e:
+        cut(invalid_cloudsmith_url)
+    assert (
+        f"Failed to reach cloudsmith. Provided invalid URL: {invalid_cloudsmith_url}"
+        in str(e)
+    )
+
+
+@pytest.mark.skipif(not CLOUDSMITH_URL, reason="Valid cloudsmith url is not set.")
+def test_check_cloudsmith_url_where_url_is_valid_expect_success():
+    cut = is_cloudsmith_url_valid
+    with does_not_raise() as e:
+        cut(CLOUDSMITH_URL)
+    expected = None
+    actual = e
+    assert actual == expected


### PR DESCRIPTION
* Old script wasn't supporting specifying --version with `<,>~=`
Install package with version appended, so for example
something like `oll-test-top-level --version ~=0.1.0,<0.2.0` now works
* Support `cloudsmith_url` during upgrading a package, for example, now oll-test-top-level[development] correctly installs from cloudsmith.
* Add *args to install_with_constraints, so we can specify `--pre` and `--upgrade` flags for example
  * NOTE: `--pre` is only provided in the cli arguments if a `pip.conf` does not exist in venv! 
* Use `install_wheels` in `attempt_upgrade` instead of pip install. now constraints are used correctly for all upgrades
* Logging improvements. We can now output the end result of upgrade process with a `--format-output ` flag

TODO in a seperate PR: unit tests for response JSON ({"success", "responseError"})