### PR TITLE
fix: add post install notifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
           architecture: x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,13 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        exclude:
+          - os: macos-latest
+            python-version: "3.8"
+          - os: macos-latest
+            python-version: "3.9"
+          - os: macos-latest
+            python-version: "3.10"
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,34 @@ and this project adheres to a _modified_ form of _[Semantic Versioning][semver]_
 
 ### Removed
 
+## [0.7.2]
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Send slack notification when post-install fails ([#18])
+
+[#18]: https://github.com/openlawlibrary/upgrade-python-package/pull/18
+
+### Removed
+
+## [0.7.1]
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Fix get latest wheel if `version_cmd` is missing ([#17])
+
+### Removed
+
+[#17]: https://github.com/openlawlibrary/upgrade-python-package/pull/17
+
 ## [0.7.0]
 
 ### Added
@@ -127,7 +155,9 @@ and this project adheres to a _modified_ form of _[Semantic Versioning][semver]_
 [#5]: https://github.com/openlawlibrary/upgrade-python-package/pull/5
 [#6]: https://github.com/openlawlibrary/upgrade-python-package/pull/6
 
-[Unreleased]:  https://github.com/openlawlibrary/upgrade-python-package/compare/0.7.0...HEAD
+[Unreleased]:  https://github.com/openlawlibrary/upgrade-python-package/compare/0.7.2...HEAD
+[0.7.2]: https://github.com/openlawlibrary/upgrade-python-package/compare/0.7.1...0.7.2
+[0.7.1]: https://github.com/openlawlibrary/upgrade-python-package/compare/0.7.0...0.7.1
 [0.7.0]: https://github.com/openlawlibrary/upgrade-python-package/compare/0.6.0...0.7.0
 [0.6.0]: https://github.com/openlawlibrary/upgrade-python-package/compare/0.5.0...0.6.0
 [0.5.0]: https://github.com/openlawlibrary/upgrade-python-package/compare/0.4.0...0.5.0

--- a/upgrade/scripts/upgrade_python_package.py
+++ b/upgrade/scripts/upgrade_python_package.py
@@ -217,7 +217,9 @@ def install_wheel(
             ]
             wheel_mapping = {k: v for (k, v) in zip(parsed_wheel_versions, wheel_paths)}
             if version_cmd is not None:
-                versions = filter_versions(SpecifierSet(version_cmd), parsed_wheel_versions)
+                versions = filter_versions(
+                    SpecifierSet(version_cmd), parsed_wheel_versions
+                )
                 wheel = wheel_mapping.get(versions[-1])
             else:
                 wheel = parsed_wheel_versions[-1]


### PR DESCRIPTION
We previously were not getting slack notifications if/when `try_running_module` failed.