### PR TITLE
fix: use `kwargs` to add keyword args to `try_running_module`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ and this project adheres to a _modified_ form of _[Semantic Versioning][semver]_
 
 ### Removed
 
+## [0.7.3]
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Fix `try_running_module` by adding `kwargs` instead of hardcoded parameters. ([#19])
+
+### Removed
+
+[#19]: https://github.com/openlawlibrary/upgrade-python-package/pull/19
+
 ## [0.7.2]
 
 ### Added
@@ -155,7 +169,8 @@ and this project adheres to a _modified_ form of _[Semantic Versioning][semver]_
 [#5]: https://github.com/openlawlibrary/upgrade-python-package/pull/5
 [#6]: https://github.com/openlawlibrary/upgrade-python-package/pull/6
 
-[Unreleased]:  https://github.com/openlawlibrary/upgrade-python-package/compare/0.7.2...HEAD
+[Unreleased]:  https://github.com/openlawlibrary/upgrade-python-package/compare/0.7.3...HEAD
+[0.7.3]: https://github.com/openlawlibrary/upgrade-python-package/compare/0.7.2...0.7.3
 [0.7.2]: https://github.com/openlawlibrary/upgrade-python-package/compare/0.7.1...0.7.2
 [0.7.1]: https://github.com/openlawlibrary/upgrade-python-package/compare/0.7.0...0.7.1
 [0.7.0]: https://github.com/openlawlibrary/upgrade-python-package/compare/0.6.0...0.7.0

--- a/upgrade/scripts/upgrade_python_package.py
+++ b/upgrade/scripts/upgrade_python_package.py
@@ -73,9 +73,9 @@ def upgrade_and_run(
         module_name = package_name.replace("-", "_")
         try_running_module(
             module_name,
+            *args,
             cloudsmith_url=cloudsmith_url,
             slack_webhook_url=slack_webhook_url,
-            *args,
         )
     return was_updated, response_err
 
@@ -458,7 +458,7 @@ def split_package_name_and_extra(package_install_cmd):
     return package_name, extra
 
 
-def try_running_module(wheel, cloudsmith_url=None, slack_webhook_url=None, *args):
+def try_running_module(wheel, *args, **kwargs):
     file_name = os.path.basename(wheel)
     module_name = file_name.split("-", 1)[0]
     # don't try running the module if it does not exists
@@ -468,7 +468,9 @@ def try_running_module(wheel, cloudsmith_url=None, slack_webhook_url=None, *args
         try:
             run_module_and_reload_uwsgi_app(module_name, *args)
         except Exception:
+            slack_webhook_url = kwargs.get("slack_webhook_url")
             if slack_webhook_url is not None:
+                cloudsmith_url = kwargs.get("cloudsmith_url")
                 send_upgrade_notification(
                     f"Failed to run module {module_name}",
                     cloudsmith_url,


### PR DESCRIPTION
This fixes a `TypeError: try_running_module() got multiple values for argument 'cloudsmith_url'` issue we started running up against.