### PR TITLE
fix: Release 0.8.1; find compatible versions fixes; remove pip vendored imports; 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           architecture: x64
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools wheel
           pip install -e .[test]
       - name: Test with pytest
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ and this project adheres to a _modified_ form of _[Semantic Versioning][semver]_
 
 ### Removed
 
+## [0.8.1]
+
+### Added
+
+### Changed
+
+- Use regular imports for `packaging` and `requests` library instead of pip vendored imports ([#23])
+
+### Fixed
+
+- Fix `find_compatible_versions` sort to use semver sort ([#23])
+
+[#23]: https://github.com/openlawlibrary/upgrade-python-package/pull/23
+
+### Removed
+
 ## [0.8.0]
 
 ### Added
@@ -183,7 +199,8 @@ and this project adheres to a _modified_ form of _[Semantic Versioning][semver]_
 [#5]: https://github.com/openlawlibrary/upgrade-python-package/pull/5
 [#6]: https://github.com/openlawlibrary/upgrade-python-package/pull/6
 
-[Unreleased]:  https://github.com/openlawlibrary/upgrade-python-package/compare/0.8.0...HEAD
+[Unreleased]:  https://github.com/openlawlibrary/upgrade-python-package/compare/0.8.1...HEAD
+[0.8.1]: https://github.com/openlawlibrary/upgrade-python-package/compare/0.8.0...0.8.1
 [0.8.0]: https://github.com/openlawlibrary/upgrade-python-package/compare/0.7.3...0.8.0
 [0.7.3]: https://github.com/openlawlibrary/upgrade-python-package/compare/0.7.2...0.7.3
 [0.7.2]: https://github.com/openlawlibrary/upgrade-python-package/compare/0.7.1...0.7.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ test =
     flake8
     pytest
     mock
+    setuptools
 
 
 [bdist_wheel]

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
 install_requires = 
     lxml >= 4.9
     requests == 2.*
+    packaging >= 24.1
 packages = upgrade.scripts
 zip_safe = False
 include_package_data = True

--- a/upgrade/scripts/find_compatible_versions.py
+++ b/upgrade/scripts/find_compatible_versions.py
@@ -6,9 +6,9 @@ from typing import Any, List, Optional
 from urllib.parse import urljoin
 
 import lxml.etree as et
-import pip._vendor.requests as requests
-from pip._vendor.packaging.utils import parse_wheel_filename
-from pip._vendor.packaging.version import Version
+import requests as requests
+from packaging.utils import parse_wheel_filename
+from packaging.version import Version
 
 from upgrade.scripts.requirements import (
     filter_versions,

--- a/upgrade/scripts/find_compatible_versions.py
+++ b/upgrade/scripts/find_compatible_versions.py
@@ -55,7 +55,7 @@ def get_compatible_upgrade_versions(
     )
     logging.debug(f"Found compatible versions: {compatible_versions}")
 
-    return sorted(compatible_versions, reverse=True)
+    return sorted(compatible_versions, reverse=True, key=Version)
 
 
 def get_installed_version(requirements_obj: Any, venv_executable: str) -> Optional[str]:

--- a/upgrade/scripts/requirements.py
+++ b/upgrade/scripts/requirements.py
@@ -67,7 +67,7 @@ def to_requirements_obj(requirements: str) -> Any:
         we import the vendored version. This way we guarantee
         that the packaging APIs are matching pip's behavior exactly.
         """
-        from pip._vendor.packaging.requirements import Requirement
+        from packaging.requirements import Requirement
 
         return Requirement(requirements)
     except Exception as e:

--- a/upgrade/scripts/upgrade_python_package.py
+++ b/upgrade/scripts/upgrade_python_package.py
@@ -7,8 +7,8 @@ import site
 from importlib import util
 from pathlib import Path
 
-from pip._vendor.packaging.specifiers import SpecifierSet
-from pip._vendor.packaging.utils import parse_wheel_filename
+from packaging.specifiers import SpecifierSet
+from packaging.utils import parse_wheel_filename
 
 from upgrade.scripts.exceptions import PipFormatDecodeFailed
 from upgrade.scripts.requirements import filter_versions

--- a/upgrade/tests/manage_venv/conftest.py
+++ b/upgrade/tests/manage_venv/conftest.py
@@ -28,6 +28,7 @@ def _create_venv(path, version, venv_name=None):
     venv_path = str(Path(path, venv_name))
     run(original_executable, "-m", "venv", venv_path)
     venv_executable = get_venv_executable(venv_path)
+    run(venv_executable, "-m", "pip", "install", "--upgrade", "pip", "setuptools", "wheel")
     run(
         venv_executable,
         "-m",

--- a/upgrade/tests/upgrade_package/test_filter_versions.py
+++ b/upgrade/tests/upgrade_package/test_filter_versions.py
@@ -1,5 +1,5 @@
 import pytest
-from pip._vendor.packaging.specifiers import SpecifierSet
+from packaging.specifiers import SpecifierSet
 
 from upgrade.scripts.requirements import filter_versions
 


### PR DESCRIPTION
- Fix `get_compatible_upgrade_versions` sort order by using `key=Version`.
- Remove `from pip._vendor` prefix from imports, as they are generally discouraged.