### PR TITLE
release: 0.9.1 regression reliability fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ and this project adheres to a _modified_ form of _[Semantic Versioning][semver]_
 
 ### Removed
 
+## [0.9.1]
+
+### Added
+
+### Changed
+
+### Fixed
+- Ensure post-install modules run when dependency-only upgrades change installed packages. ([#26])
+- Fail `manage_venv` upgrade flow when child `upgrade` commands exit non-zero instead of silently continuing. ([#26])
+
+### Removed
+
+[#26]: https://github.com/openlawlibrary/upgrade-python-package/pull/26
+
 ## [0.9.0]
 
 ### Added
@@ -215,7 +229,9 @@ and this project adheres to a _modified_ form of _[Semantic Versioning][semver]_
 [#5]: https://github.com/openlawlibrary/upgrade-python-package/pull/5
 [#6]: https://github.com/openlawlibrary/upgrade-python-package/pull/6
 
-[Unreleased]:  https://github.com/openlawlibrary/upgrade-python-package/compare/0.8.1...HEAD
+[Unreleased]:  https://github.com/openlawlibrary/upgrade-python-package/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/openlawlibrary/upgrade-python-package/compare/v0.9.0...v0.9.1
+[0.9.0]: https://github.com/openlawlibrary/upgrade-python-package/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/openlawlibrary/upgrade-python-package/compare/0.8.0...0.8.1
 [0.8.0]: https://github.com/openlawlibrary/upgrade-python-package/compare/0.7.3...0.8.0
 [0.7.3]: https://github.com/openlawlibrary/upgrade-python-package/compare/0.7.2...0.7.3

--- a/upgrade/scripts/manage_venv.py
+++ b/upgrade/scripts/manage_venv.py
@@ -140,7 +140,12 @@ def upgrade_venv(
             if update_from_local_wheels:
                 upgrade_args.append("--update-from-local-wheels")
 
-            result += run(*(upgrade_args), check=False) or ""
+            upgrade_output = run(*(upgrade_args), check=False)
+            if upgrade_output is None:
+                raise UpgradeError(
+                    f"Upgrade command failed for dependency {dependency}"
+                )
+            result += upgrade_output
 
         return result
     except Exception as e:

--- a/upgrade/scripts/upgrade_python_package.py
+++ b/upgrade/scripts/upgrade_python_package.py
@@ -401,6 +401,27 @@ def attempt_to_install_version(
     return success, resp
 
 
+def _get_installed_packages_snapshot():
+    try:
+        packages_json = pip("list", "--format", "json")
+        if not packages_json:
+            return None
+        decoder = json.JSONDecoder()
+        parsed_results, _ = decoder.raw_decode(str(packages_json))
+    except Exception as e:
+        logging.warning("Failed to read installed package snapshot: %s", e)
+        return None
+
+    snapshot = {}
+    for package in parsed_results:
+        name = package.get("name")
+        version = package.get("version")
+        if name is None or version is None:
+            continue
+        snapshot[str(name)] = str(version)
+    return snapshot
+
+
 def attempt_upgrade(
     package_install_cmd,
     cloudsmith_url=None,
@@ -421,6 +442,7 @@ def attempt_upgrade(
     args = tuple(arg for arg in pip_args)
 
     package_name, _ = split_package_name_and_extra(package_install_cmd)
+    before_snapshot = _get_installed_packages_snapshot()
     before_version = is_package_already_installed(package_name)
 
     resp = install_wheel(
@@ -434,8 +456,13 @@ def attempt_upgrade(
         constraints_path,
         *args,
     )
+
+    after_snapshot = _get_installed_packages_snapshot()
     after_version = is_package_already_installed(package_name)
+
     was_upgraded = before_version != after_version
+    if not was_upgraded and before_snapshot is not None and after_snapshot is not None:
+        was_upgraded = before_snapshot != after_snapshot
     if was_upgraded:
         logging.info('"%s" package was upgraded.', package_install_cmd)
     else:


### PR DESCRIPTION
## Summary
- fix: restore post-install execution when dependency-only upgrades change installed packages without bumping the top-level package version
- fix: fail `manage_venv` when child `upgrade` commands exit non-zero instead of silently continuing
- docs: draft `0.9.1` changelog section and update compare links for `Unreleased`, `0.9.1`, and `0.9.0`

## Why
`0.9.0` introduced upgrade-detection/output-handling changes that could mask meaningful upgrade semantics. In practice this could skip post-install hooks or allow a failed child upgrade command to be treated as an empty-success path in `manage_venv`.

This patch release restores fail-fast and post-install behavior so operational automation remains predictable.