### PR TITLE
fix: eliminate setuptools packaging warnings during uv build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to a _modified_ form of _[Semantic Versioning][semver]_
 ### Added
 
 ### Changed
-- Replace table-style `project.license` metadata with SPDX `Apache-2.0` and remove deprecated license classifiers so packaging remains compatible with modern setuptools behavior.
+- Keep file-based `project.license` metadata for Python 3.8/setuptools compatibility while removing the deprecated license classifier, avoiding install-time config errors on older build backends.
 
 ### Fixed
 - Remove stale `MANIFEST.in` include/exclude rules that referenced files not shipped in this repo, eliminating noisy build-time "no files found" warnings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ and this project adheres to a _modified_ form of _[Semantic Versioning][semver]_
 ### Added
 
 ### Changed
+- Replace table-style `project.license` metadata with SPDX `Apache-2.0` and remove deprecated license classifiers so packaging remains compatible with modern setuptools behavior.
 
 ### Fixed
-
+- Remove stale `MANIFEST.in` include/exclude rules that referenced files not shipped in this repo, eliminating noisy build-time "no files found" warnings.
 ### Removed
 
 ## [0.9.0]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,19 +1,1 @@
-recursive-exclude __pycache__  *.pyc *.pyo *.orig
-
-exclude *.js*
-exclude *.git*
-exclude *.coveragerc
-exclude *.sh
-exclude proc*
-exclude pylint*
-
-include requirements*.*
-exclude requirements-dev.*
-include *.py
-
-prune .git
-prune env
 prune upgrade/tests*
-
-recursive-exclude docs *
-recursive-exclude upgrade/tests *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "upgrade-python-package"
 description = "A script for upgrading python packages"
 readme = "README.md"
 requires-python = ">=3.8"
-license = { file = "LICENSE" }
+license = "Apache-2.0"
 authors = [
   { name = "Open Law Library", email = "info@openlawlib.org" },
 ]
@@ -21,7 +21,6 @@ classifiers = [
   "Intended Audience :: Developers",
   "Intended Audience :: Information Technology",
   "Topic :: Software Development :: Build Tools",
-  "License :: OSI Approved :: Apache Software License",
   "Natural Language :: English",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ name = "upgrade-python-package"
 description = "A script for upgrading python packages"
 readme = "README.md"
 requires-python = ">=3.8"
-license = "Apache-2.0"
+license = { file = "LICENSE" }
 authors = [
   { name = "Open Law Library", email = "info@openlawlib.org" },
 ]


### PR DESCRIPTION
## Summary
- keep a Python 3.8-compatible `project.license` table in `pyproject.toml` so editable installs do not fail when older setuptools is resolved
- remove deprecated license classifiers to reduce avoidable packaging deprecation noise while preserving cross-version install compatibility
- simplify `MANIFEST.in` to only exclude intentionally omitted test fixtures, removing repeated non-actionable file-matching warnings
- document the packaging warning cleanup and license-metadata compatibility tradeoff in the Unreleased changelog

## Verification
- run `uv build`
- run `uv pip install -p .venv -e ".[test]"`