### PR TITLE
feat(logging): consolidate log format to match OLL standard

### DIFF
--- a/upgrade/scripts/logging_config.py
+++ b/upgrade/scripts/logging_config.py
@@ -15,8 +15,7 @@ from logging.handlers import WatchedFileHandler
 from pathlib import Path
 from typing import Optional, Tuple
 
-DEFAULT_LOG_FORMAT = "%(asctime)s %(levelname)s %(name)s %(message)s"
-DEFAULT_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
+DEFAULT_LOG_FORMAT = "%(asctime)s [%(levelname)s] [%(name)s:%(lineno)s] %(message)s"
 UPGRADE_HANDLER_ATTR = "_upgrade_handler"
 
 
@@ -77,7 +76,7 @@ def configure_logging(
         not _is_upgrade_handler(handler) for handler in root.handlers
     )
 
-    formatter = logging.Formatter(DEFAULT_LOG_FORMAT, datefmt=DEFAULT_DATE_FORMAT)
+    formatter = logging.Formatter(DEFAULT_LOG_FORMAT)
 
     if test:
         stream_handler = logging.StreamHandler(sys.stderr)


### PR DESCRIPTION
Update DEFAULT_LOG_FORMAT to %(asctime)s [%(levelname)s] [%(name)s:%(lineno)s] %(message)s and remove DEFAULT_DATE_FORMAT so timestamps use Python's default YYYY-MM-DD HH:MM:SS,mmm, consistent with portal and publish-server.